### PR TITLE
Update kvm-qemu.sh

### DIFF
--- a/Virtualization/kvm-qemu.sh
+++ b/Virtualization/kvm-qemu.sh
@@ -151,7 +151,7 @@ function install_libvirt() {
 Package: libvirt-bin
 Pin: release *
 Pin-Priority: -1
- Package: libvirt0
+Package: libvirt0
 Pin: release *
 Pin-Priority: -1
 EOH


### PR DESCRIPTION
A simple blank character on line 154 meant that the OS did not take into account the exception for not installing libvirt0 with apt. Also, libvirt-bin is deprecated in the last versions of Ubuntu.