### PR TITLE
Add * after chown /opt/CAPEv2/

### DIFF
--- a/Sandbox/cape2.sh
+++ b/Sandbox/cape2.sh
@@ -944,7 +944,7 @@ function install_CAPE() {
     #chown -R root:${USER} /usr/var/malheur/
     #chmod -R =rwX,g=rwX,o=X /usr/var/malheur/
     # Adapting owner permissions to the ${USER} path folder
-    chown ${USER}:${USER} -R "/opt/CAPEv2/"
+    chown ${USER}:${USER} -R "/opt/CAPEv2/*"
 
     pip3 install -r /opt/CAPEv2/requirements.txt
 


### PR DESCRIPTION
In the latest version of Ubuntu 20.04 and in the scripts current state, it does not give the user ownership over /opt/CAPEv2 without the * after it. For whatever reason adding the wildcard at the end resolves the issue.