### PR TITLE
Update cape2.sh (install_yara function: error parsing version)

### DIFF
--- a/Sandbox/cape2.sh
+++ b/Sandbox/cape2.sh
@@ -563,12 +563,12 @@ function install_yara() {
     ./bootstrap.sh
     ./configure --enable-cuckoo --enable-magic --enable-dotnet --enable-profiling
     make -j"$(getconf _NPROCESSORS_ONLN)"
-    yara_version_only="$yara_version|cut -c 2-"
+    yara_version_only=$(echo $yara_version|cut -c 2-)
     echo -e "Package: yara\nVersion: $yara_version_only\nArchitecture: $ARCH\nMaintainer: $MAINTAINER\nDescription: yara-$yara_version" > /tmp/yara_builded/DEBIAN/control
     make -j"$(nproc)" install DESTDIR=/tmp/yara_builded
     dpkg-deb --build --root-owner-group /tmp/yara_builded
     dpkg -i --force-overwrite /tmp/yara_builded.deb
-    #checkinstall -D --pkgname="yara-$yara_version" --pkgversion="$yara_version|cut -c 2-" --default
+    #checkinstall -D --pkgname="yara-$yara_version" --pkgversion="$yara_version_only" --default
     ldconfig
 
     cd /tmp || return


### PR DESCRIPTION
The variable yara_version_only was not being initialized appropriately. An echo was missing, resulting the initialization of such variable into something like: "v4.1.3|cut -c 2-".

Due to this fact, the creation of the .deb file fails, returning the installation of the yara package an error:
```
dpkg-deb: error: parsing file '/tmp/yara_builded/DEBIAN/control' near line 2 package 'yara':
 'Version' field value 'v4.1.3|cut -c 2-': version string has embedded spaces
dpkg: error: cannot access archive '/tmp/yara_builded.deb': No such file or directory
```
The proposed solution has been tested and fixes the issue.