### PR TITLE
pip3 install flare-capa works

### DIFF
--- a/Sandbox/cape2.sh
+++ b/Sandbox/cape2.sh
@@ -705,15 +705,8 @@ function dependencies() {
     # if __name__ == '__main__':
     #     sys.exit(__main__._main())
 
-    # pip3 install flare-capa fails for me
-    cd /tmp || return
-    if [ ! -d /tmp/capa ]; then
-        git clone --recurse-submodules https://github.com/mandiant/capa.git
-    fi
-    cd capa || return
-    git pull
-    git submodule update --init rules
-    pip3 install .
+    # https://github.com/mandiant/capa
+    pip3 install flare-capa
 
     # re2
     apt install libre2-dev -y


### PR DESCRIPTION
Hello,

When doing `git clone --recurse-submodules https://github.com/mandiant/capa.git`, if SSH key authentication is not configured on the host, the command prompts to accept github.com, and then fails.
Even though mandiant use relative urls in their `.gitmodules`, which means our git clone should retrieve submodules with HTTPS because the repo is cloned using HTTPS, it still try SSH, and I don't understand why.

Installing flare-capa using pip3 works for me, tested on Ubuntu Server 20.04 LTS.