### PR TITLE
fix qemu 7.1.0-rc3 build

### DIFF
--- a/Virtualization/kvm-qemu.sh
+++ b/Virtualization/kvm-qemu.sh
@@ -709,7 +709,7 @@ function install_virt_manager() {
     systemctl start virtstoraged.service
 
     # i440FX-Issue Win7: Unable to complete install: 'XML error: The PCI controller with index='0' must be model='pci-root' for this machine type, but model='pcie-root' was found instead'
-    # Workaround: Edit Overiew in XML view and delet all controller entires with type="pci"
+    # Workaround: Edit Overiew in XML view and delete all controller entries with type="pci"
     # Example:
     # <controller type="pci" model="pcie-root"/>
     # <controller type="pci" model="pcie-root-port"/>
@@ -876,7 +876,7 @@ function install_qemu() {
         add-apt-repository universe -y
         apt update 2>/dev/null
         aptitude install -f python3-pip openbios-sparc openbios-ppc libssh2-1-dev vde2 liblzo2-dev libghc-gtk3-dev libsnappy-dev libbz2-dev libxml2-dev google-perftools libgoogle-perftools-dev libvde-dev python3-sphinx-rtd-theme -y
-        aptitude install -f debhelper libusb-1.0-0-dev libxen-dev uuid-dev xfslibs-dev libjpeg-dev libusbredirparser-dev device-tree-compiler texinfo libbluetooth-dev libbrlapi-dev libcap-ng-dev libcurl4-gnutls-dev libfdt-dev gnutls-dev libiscsi-dev libncurses5-dev libnuma-dev libcacard-dev librados-dev librbd-dev libsasl2-dev libseccomp-dev libspice-server-dev libaio-dev libcap-dev libattr1-dev libpixman-1-dev libgtk2.0-bin  libxml2-utils systemtap-sdt-dev uml-utilities -y
+        aptitude install -f debhelper libusb-1.0-0-dev libxen-dev uuid-dev xfslibs-dev libjpeg-dev libusbredirparser-dev device-tree-compiler texinfo libbluetooth-dev libbrlapi-dev libcap-ng-dev libcurl4-gnutls-dev libfdt-dev gnutls-dev libiscsi-dev libncurses5-dev libnuma-dev libcacard-dev librados-dev librbd-dev libsasl2-dev libseccomp-dev libspice-server-dev libaio-dev libcap-dev libattr1-dev libpixman-1-dev libgtk2.0-bin  libxml2-utils systemtap-sdt-dev uml-utilities libcapstone-dev -y
         # qemu docs required
         PERL_MM_USE_DEFAULT=1 perl -MCPAN -e install "Perl/perl-podlators"
         pip3 install sphinx ninja
@@ -901,7 +901,7 @@ function install_qemu() {
             cd qemu-$qemu_version || return
             # add in future --enable-netmap https://sgros-students.blogspot.com/2016/05/installing-and-testing-netmap.html
             # remove --target-list=i386-softmmu,x86_64-softmmu,i386-linux-user,x86_64-linux-user  if you want all targets
-                ./configure $QTARGETS --prefix=/usr --libexecdir=/usr/lib/qemu --localstatedir=/var --bindir=/usr/bin/ --enable-gnutls --enable-docs --enable-gtk --enable-vnc --enable-vnc-sasl --enable-vnc-png --enable-vnc-jpeg --enable-curl --enable-kvm  --enable-linux-aio --enable-cap-ng --enable-vhost-net --enable-vhost-crypto --enable-spice --enable-usb-redir --enable-lzo --enable-snappy --enable-bzip2 --enable-coroutine-pool --enable-jemalloc --enable-replication --enable-tools --enable-capstone
+                ./configure $QTARGETS --prefix=/usr --libexecdir=/usr/lib/qemu --localstatedir=/var --bindir=/usr/bin/ --enable-gnutls --enable-docs --enable-gtk --enable-vnc --enable-vnc-sasl --enable-vnc-jpeg --enable-curl --enable-kvm  --enable-linux-aio --enable-cap-ng --enable-vhost-net --enable-vhost-crypto --enable-spice --enable-usb-redir --enable-lzo --enable-snappy --enable-bzip2 --enable-coroutine-pool --enable-jemalloc --enable-replication --enable-tools --enable-capstone
             if  [ $? -eq 0 ]; then
                 echo '[+] Starting Install it'
                 if [ -f /usr/share/qemu/qemu_logo_no_text.svg ]; then


### PR DESCRIPTION
build failuers:

guess there is no --enable-vnc-png config option anymore
![Screenshot from 2022-08-25 13-35-23](https://user-images.githubusercontent.com/35531629/186663742-66f741c1-dd0e-47c5-9794-9bde156c93c5.png)

/tmp/qemu-7.1.0-rc3/configure --help: 
![Screenshot from 2022-08-25 13-36-18](https://user-images.githubusercontent.com/35531629/186663769-ace8b440-0cfd-4f92-9b49-b0aa6fe1fd44.png)

capstone is needed
![Screenshot from 2022-08-25 13-40-25](https://user-images.githubusercontent.com/35531629/186663975-e2f4c5cc-3834-48c9-861c-a9a93f6def25.png)
see also: https://wiki.qemu.org/ChangeLog/7.1

